### PR TITLE
fix: avoid double-slashes after HOST part

### DIFF
--- a/bin/jenkinsOp.sh
+++ b/bin/jenkinsOp.sh
@@ -4,7 +4,7 @@ SELECT=$1
 
 JENKINS="jenkins.ivyteam.io"
 if [ -z "${BASE_URL}" ]; then
-  BASE_URL="https://${JENKINS}/"
+  BASE_URL="https://${JENKINS}"
 fi
 DIR="$( cd "$( dirname "$BASH_SOURCE" )" && pwd )"
 


### PR DESCRIPTION
not a real functional problem, but confusing to the user

![double-slasher](https://github.com/user-attachments/assets/7f973248-0c0f-46c2-b719-0bcfbebc5750)
