### PR TITLE
Handle "view already exist" response and open it in browser

### DIFF
--- a/bin/jenkinsOp.sh
+++ b/bin/jenkinsOp.sh
@@ -224,14 +224,8 @@ createView(){
     --form json="{'name': '${BRANCH_NAME}', 'mode': 'hudson.model.ListView', 'useincluderegex': 'on', 'includeRegex': '${ISSUE_REGEX}', 'recurse': 'true'}" \
     "${MYVIEWS_URL}/createView")
 
-  # if Jenkins says the view already exists, open it instead of spitting HTML
   if echo "$RESPONSE" | grep -qi "view already exists"; then
     echo "View already exists: ${VIEW_URL}"
-    if command -v xdg-open >/dev/null 2>&1; then
-      xdg-open "${VIEW_URL}" >/dev/null 2>&1 &
-    elif command -v open >/dev/null 2>&1; then
-      open "${VIEW_URL}" >/dev/null 2>&1 &
-    fi
   else
     echo "View created: ${VIEW_URL}"
   fi


### PR DESCRIPTION
so when i try to pick `!new_view` in jenkinsCli it just spits a 10 mile html error response.

now instead of that it will just tell you that and open the view in your default browser (should work for linux and mac)

do you think this behavior is fine or should default be to not open and maybe make it configurable in the .env ? (for me personally i think its much better if it opens it for me)

